### PR TITLE
fix calling show_launcher() in notebook without passing height

### DIFF
--- a/jdaviz/core/launcher.py
+++ b/jdaviz/core/launcher.py
@@ -163,13 +163,14 @@ class Launcher(v.VuetifyTemplate):
 
     def vue_launch_config(self, config):
         helper = _launch_config_with_data(config, self.loaded_data, show=False)
-        helper.app.layout.height = self.height
-        helper.app.state.settings['context']['notebook']['max_height'] = self.height
+        if self.height is not None:
+            helper.app.layout.height = self.height
+            helper.app.state.settings['context']['notebook']['max_height'] = self.height
         self.main.color = 'transparent'
         self.main.children = [helper.app]
-        
 
-def show_launcher(configs=ALL_JDAVIZ_CONFIGS, height="100%"):
+
+def show_launcher(configs=ALL_JDAVIZ_CONFIGS, height=None):
     '''Display an interactive Jdaviz launcher to select your data and compatible configuration
 
     Parameters

--- a/jdaviz/jdaviz_cli_launcher.ipynb
+++ b/jdaviz/jdaviz_cli_launcher.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from jdaviz.core.launcher import show_launcher\n",
     "\n",
-    "show_launcher()"
+    "show_launcher(height='100%')"
    ]
   }
  ],


### PR DESCRIPTION
This PR fixes calling `show_launcher()` in the notebook without passing the `height` kwarg while still preserving the full-screen behavior in the standalone mode (by passing `height='100%'` from the notebook).